### PR TITLE
fix: add more spacing to give more space to breath

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -13,13 +13,18 @@ const Card = ({ title, description, image }) => {
       <style jsx>{`
         div {
           width: 100%;
-          padding: 1rem 2rem 1rem 0;
+          padding: 1rem 2rem;
+        }
+
+        img {
+          width: 100%;
         }
 
         h3 {
           color: var(--color-primary);
           letter-spacing: -1px;
           font-size: 2rem;
+          margin-top: 1rem;
           margin-bottom: 0.5rem;
         }
 

--- a/pages/services.js
+++ b/pages/services.js
@@ -111,10 +111,10 @@ const Section = ({
     <div className={`_container ${isLast ? '_container--has-border' : ''}`}>
       <div className='o-container'>
         {isTitle ? (
-          <>
+          <div className='_section-title'>
             <h2>{title}</h2>
             <p>{description}</p>
-          </>
+          </div>
         ) : (
           ''
         )}
@@ -145,6 +145,10 @@ const Section = ({
         ._container--has-border {
           border-top: 1px solid;
           border-bottom: 1px solid;
+        }
+
+        ._section-title {
+          padding: 0 2rem;
         }
 
         @media screen and (min-width: 640px) {


### PR DESCRIPTION
Just small improvement, as this PR's title says.

Regression (the *actual* affected change is only on card & the "section title" component, just ignore the rest):

![diffs](https://user-images.githubusercontent.com/6561394/83485241-d7450900-a4d0-11ea-892f-24f383422838.png)
